### PR TITLE
Fix require dependency resolve

### DIFF
--- a/src/fengari-loader.js
+++ b/src/fengari-loader.js
@@ -89,7 +89,7 @@ exports.default = function(source) {
 				let lua_name = lua_dependencies_keys[i];
 				/* if lua requires "foo" then look for webpack dependency "foo" */
 				lua_dependencies[lua_name] = await new Promise((resolve, reject) => {
-					this.resolve(process.cwd(), lua_name, (err, result) => {
+					this.resolve(this.context, lua_name, (err, result) => {
 						if (err) reject(err);
 						else resolve(result);
 					});

--- a/src/fengari-loader.js
+++ b/src/fengari-loader.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const process = require('process');
 const loader_utils = require('loader-utils');
 const validateOptions = require('schema-utils');
 


### PR DESCRIPTION
In my opinion, the `this.resolve` should use `this.context`, enabling relative require paths that use './' or '../' to be found correctly.

An example that makes use of this is here: 
[nwcutlib.lua-web](https://github.com/noteworthycomposer-org/nwcutlib-web/blob/master/src/nwcutlib.lua-web)